### PR TITLE
Expose OTLP port 4317 on Datadog Agent container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - 6379
   datadog:
     image: datadog/agent:7.35.0
+    ports:
+      - 4317
     environment:
       # DD_LOG_LEVEL: trace
       DD_API_KEY: ${DD_API_KEY}


### PR DESCRIPTION
Fixes DataDog/datadog-agent#11737.

I think this is the only piece missing to make this work. Once I do this, I can see traces being sent to port 5003 and being sent to Datadog. Since we don't know what port people will use, it needs to be exposed explicitly on the container, otherwise nothing will reach the Agent.